### PR TITLE
Fix motion vectors

### DIFF
--- a/Runtime/MotionBlur.cs
+++ b/Runtime/MotionBlur.cs
@@ -24,7 +24,7 @@ namespace kTools.Motion
         /// The minimum velocity for the motion blur filter to be applied.
         /// </summary>
         [Tooltip("The minimum velocity for the motion blur filter to be applied.")]
-        public ClampedFloatParameter threshold = new ClampedFloatParameter(0f, 0f, 1f);
+        public ClampedFloatParameter threshold = new ClampedFloatParameter(.01f, 0f, 1f);
         
         /// <summary>
         /// Is the component active?

--- a/Runtime/MotionBlur.cs
+++ b/Runtime/MotionBlur.cs
@@ -19,6 +19,12 @@ namespace kTools.Motion
         /// </summary>
         [Tooltip("The strength of the motion blur filter. Acts as a multiplier for velocities.")]
         public ClampedFloatParameter intensity = new ClampedFloatParameter(0f, 0f, 1f);
+
+        /// <summary>
+        /// The minimum velocity for the motion blur filter to be applied.
+        /// </summary>
+        [Tooltip("The minimum velocity for the motion blur filter to be applied.")]
+        public ClampedFloatParameter threshold = new ClampedFloatParameter(0f, 0f, 1f);
         
         /// <summary>
         /// Is the component active?

--- a/Runtime/MotionBlurRenderPass.cs
+++ b/Runtime/MotionBlurRenderPass.cs
@@ -53,6 +53,7 @@ namespace kTools.Motion
             {
                 // Set Material properties from VolumeComponent
                 m_Material.SetFloat("_Intensity", m_MotionBlur.intensity.value);
+                m_Material.SetFloat("_Threshold", m_MotionBlur.threshold.value);
 
                 // TODO: Why doesnt RenderTargetHandle.CameraTarget work?
                 var colorTextureIdentifier = new RenderTargetIdentifier("_CameraColorTexture");

--- a/Shaders/CameraMotionVectors.shader
+++ b/Shaders/CameraMotionVectors.shader
@@ -69,8 +69,7 @@
 
                 // Convert velocity from Clip space (-1..1) to NDC 0..1 space
                 // Note it doesn't mean we don't have negative value, we store negative or positive offset in NDC space.
-                // Note: ((positionVP * 0.5 + 0.5) - (previousPositionVP * 0.5 + 0.5)) = (velocity * 0.5)
-                return half4(velocity.xy * 0.5, 0, 0);
+                return half4(velocity.xy * 0.5 + .5, 0, 0);
             }
 
             ENDHLSL

--- a/Shaders/MotionBlur.shader
+++ b/Shaders/MotionBlur.shader
@@ -20,6 +20,7 @@
     TEXTURE2D(_MotionVectorTexture);       SAMPLER(sampler_MotionVectorTexture);
 
     float _Intensity;
+    float _Threshold;
     float4 _MainTex_TexelSize;
 
     // -------------------------------------
@@ -64,7 +65,15 @@
         UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 
         float2 uv = UnityStereoTransformScreenSpaceTex(input.uv.xy);
-        float2 velocity = (SAMPLE_TEXTURE2D(_MotionVectorTexture, sampler_MotionVectorTexture, uv).rg - .5) * _Intensity;
+        float2 velocity = SAMPLE_TEXTURE2D(_MotionVectorTexture, sampler_MotionVectorTexture, uv).rg - .5;
+
+        if(length(velocity) < _Threshold)
+        {
+            return SAMPLE_TEXTURE2D_X(_MainTex, sampler_PointClamp, uv);
+        }
+
+        velocity *= _Intensity;
+
         float randomVal = InterleavedGradientNoise(uv * _MainTex_TexelSize.zw, 0);
         float invSampleCount = rcp(iterations * 2.0);
 

--- a/Shaders/MotionBlur.shader
+++ b/Shaders/MotionBlur.shader
@@ -64,7 +64,7 @@
         UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 
         float2 uv = UnityStereoTransformScreenSpaceTex(input.uv.xy);
-        float2 velocity = SAMPLE_TEXTURE2D(_MotionVectorTexture, sampler_MotionVectorTexture, uv).rg * _Intensity;
+        float2 velocity = (SAMPLE_TEXTURE2D(_MotionVectorTexture, sampler_MotionVectorTexture, uv).rg - .5) * _Intensity;
         float randomVal = InterleavedGradientNoise(uv * _MainTex_TexelSize.zw, 0);
         float invSampleCount = rcp(iterations * 2.0);
 

--- a/Shaders/ObjectMotionVectors.shader
+++ b/Shaders/ObjectMotionVectors.shader
@@ -105,7 +105,6 @@
 
                 // Convert from Clip space (-1..1) to NDC 0..1 space.
                 // Note it doesn't mean we don't have negative value, we store negative or positive offset in NDC space.
-                // Note: ((positionCS * 0.5 + 0.5) - (previousPositionCS * 0.5 + 0.5)) = (velocity * 0.5)
                 return float4(velocity.xy * 0.5 + .5, 0, 0);
             }
             ENDHLSL

--- a/Shaders/ObjectMotionVectors.shader
+++ b/Shaders/ObjectMotionVectors.shader
@@ -106,7 +106,7 @@
                 // Convert from Clip space (-1..1) to NDC 0..1 space.
                 // Note it doesn't mean we don't have negative value, we store negative or positive offset in NDC space.
                 // Note: ((positionCS * 0.5 + 0.5) - (previousPositionCS * 0.5 + 0.5)) = (velocity * 0.5)
-                return float4(velocity.xy * 0.5, 0, 0);
+                return float4(velocity.xy * 0.5 + .5, 0, 0);
             }
             ENDHLSL
         }


### PR DESCRIPTION
The original motion vectors are incorrectly converted from clip space (-1..1) to NDC 0..1 space.
This results in the filter only working when motion is in the +x or +y screen space directions.

Previously, when viewing a spinning object along the rotation axis:
-The top left quadrant would receive the correct filter
-The top right and bottom left quadrants would receive motion blur in only one direction
-The bottom right quadrant would not receive the filter