### PR TITLE
Fix memory leak

### DIFF
--- a/Runtime/MotionBlurRenderPass.cs
+++ b/Runtime/MotionBlurRenderPass.cs
@@ -33,7 +33,8 @@ namespace kTools.Motion
         {
             // Set data
             m_MotionBlur = motionBlur;
-            m_Material = new Material(Shader.Find(kMotionBlurShader));
+			if(!m_Material)
+			    m_Material = new Material(Shader.Find(kMotionBlurShader));
         }
 #endregion
 

--- a/Runtime/MotionBlurRenderPass.cs
+++ b/Runtime/MotionBlurRenderPass.cs
@@ -33,8 +33,8 @@ namespace kTools.Motion
         {
             // Set data
             m_MotionBlur = motionBlur;
-			if(!m_Material)
-			    m_Material = new Material(Shader.Find(kMotionBlurShader));
+            if(!m_Material)
+                m_Material = new Material(Shader.Find(kMotionBlurShader));
         }
 #endregion
 

--- a/Runtime/MotionVectorRenderPass.cs
+++ b/Runtime/MotionVectorRenderPass.cs
@@ -43,10 +43,10 @@ namespace kTools.Motion
             m_MotionData = motionData;
             m_MotionBlur = motionBlur;
             m_layerMask = layerMask;
-			if(!m_CameraMaterial)
+            if(!m_CameraMaterial)
                 m_CameraMaterial = new Material(Shader.Find(kCameraShader));
             if(!m_ObjectMaterial)
-			    m_ObjectMaterial = new Material(Shader.Find(kObjectShader));
+                m_ObjectMaterial = new Material(Shader.Find(kObjectShader));
         }
 
         public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)

--- a/Runtime/MotionVectorRenderPass.cs
+++ b/Runtime/MotionVectorRenderPass.cs
@@ -43,8 +43,10 @@ namespace kTools.Motion
             m_MotionData = motionData;
             m_MotionBlur = motionBlur;
             m_layerMask = layerMask;
-            m_CameraMaterial = new Material(Shader.Find(kCameraShader));
-            m_ObjectMaterial = new Material(Shader.Find(kObjectShader));
+			if(!m_CameraMaterial)
+                m_CameraMaterial = new Material(Shader.Find(kCameraShader));
+            if(!m_ObjectMaterial)
+			    m_ObjectMaterial = new Material(Shader.Find(kObjectShader));
         }
 
         public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)


### PR DESCRIPTION
Garbage collection does not collect Unity materials once they have no references.
This workaround checks if the materials already exist before creating them.